### PR TITLE
Update GitReleaseManager to 0.7.0

### DIFF
--- a/Cake.Wyam.Recipe/Content/tools.cake
+++ b/Cake.Wyam.Recipe/Content/tools.cake
@@ -2,7 +2,7 @@
 // TOOLS
 ///////////////////////////////////////////////////////////////////////////////
 
-private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.5.0";
+private const string GitReleaseManagerTool = "#tool nuget:?package=gitreleasemanager&version=0.7.0";
 private const string GitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=3.6.2";
 private const string KuduSyncTool = "#tool nuget:?package=KuduSync.NET&version=1.3.1";
 private const string WyamTool = "#tool nuget:?package=Wyam&version=1.0.0";


### PR DESCRIPTION
Update GitReleaseManager to 0.7.0 to make it work with GitHubs recent deprecation of old TLS versions