### PR TITLE
(build) Correctly invalidate cache on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,4 +22,4 @@ branches:
 #  Build Cache                    #
 #---------------------------------#
 cache:
-- tools -> setup.cake
+- tools -> recipe.cake


### PR DESCRIPTION
Correctly invalidate cache on AppVeyor due to changed build script (https://github.com/cake-contrib/Cake.Wyam.Recipe/commit/d9ba8f4068b7330a5aec7214063377495a1e2e20)