### PR TITLE
Add cake-version.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,4 +295,5 @@ tools/**
 *.xsd.cs
 
 Cake.Wyam.Recipe/Content/version.cake
+Cake.Wyam.Recipe/cake-version.yml
 BuildArtifacts/

--- a/recipe.cake
+++ b/recipe.cake
@@ -30,6 +30,17 @@ BuildParameters.Tasks.CleanTask
 
 Task("Generate-Version-File")
     .Does<BuildVersion>((context, buildVersion) => {
+        // Write metadata to configuration file
+        System.IO.File.WriteAllText(
+            "./Cake.Wyam.Recipe/cake-version.yml",
+            @"TargetCakeVersion: 0.33.0
+TargetFrameworks:
+- netcoreapp2.0
+- netcoreapp2.1
+- net46"
+        );
+
+        // Write metadata to class for use when running a build
         var buildMetaDataCodeGen = TransformText(@"
         public class BuildMetaData
         {


### PR DESCRIPTION
Add `cake-version.yml` file to Cake.Wyam.Recipe, which is used by Cake Addin Discoverer.

Generated file `cake-version.yml` in root folder will look like this:

```
TargetCakeVersion: 0.33.0
TargetFrameworks:
- netcoreapp2.0
- netcoreapp2.1
- net46
```