### PR TITLE
Replace Cake.Figlet with Spectre.Console

### DIFF
--- a/Cake.Wyam.Recipe/Content/addins.cake
+++ b/Cake.Wyam.Recipe/Content/addins.cake
@@ -2,7 +2,6 @@
 // ADDINS
 ///////////////////////////////////////////////////////////////////////////////
 
-#addin nuget:?package=Cake.Figlet&version=2.0.1
 #addin nuget:?package=Cake.Git&version=2.0.0
 #addin nuget:?package=Cake.Kudu&version=2.0.0
 #addin nuget:?package=Cake.Wyam&version=2.2.13

--- a/Cake.Wyam.Recipe/Content/build.cake
+++ b/Cake.Wyam.Recipe/Content/build.cake
@@ -10,7 +10,8 @@ var publishingError = false;
 
 Setup(context =>
 {
-    Information(Figlet(BuildParameters.Title));
+    Spectre.Console.AnsiConsole.Write(
+        new Spectre.Console.FigletText(BuildParameters.Title));
 
     Information("Starting Setup...");
 


### PR DESCRIPTION
Replace Cake.Figlet addin with Spectre.Console calls, which is already shipped as part of Cake