### PR TITLE
(#81) Consume KuduSync .NET tool from Azure Artifacts

### DIFF
--- a/Cake.Wyam.Recipe/Content/toolsettings.cake
+++ b/Cake.Wyam.Recipe/Content/toolsettings.cake
@@ -16,7 +16,7 @@ public static class ToolSettings
         string wyamTool = "#tool nuget:?package=Wyam&version=2.2.9",
         string wyamGlobalTool = "#tool dotnet:?package=Wyam.Tool&version=2.2.9",
         // This is using an unofficial build of kudusync so that we can have a .Net Global tool version.  This was generated from this PR: https://github.com/projectkudu/KuduSync.NET/pull/27
-        string kuduSyncGlobalTool = "#tool dotnet:https://www.myget.org/F/cake-contrib/api/v3/index.json?package=KuduSync.Tool&version=1.5.4-g3916ad7218"
+        string kuduSyncGlobalTool = "#tool dotnet:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=KuduSync.Tool&version=1.5.4-g13cb5857b6"
     )
     {
         KuduSyncTool = kuduSyncTool;


### PR DESCRIPTION
Consumes KuduSync .NET tool from Azure Artifacts to avoid having a dependency on MyGet by default, which is currently down.

Fixes #81 